### PR TITLE
Path don't work on Linux beause of case sensitiveness (FIX)

### DIFF
--- a/files.qip
+++ b/files.qip
@@ -8,7 +8,7 @@ set_global_assignment -name VHDL_FILE rtl/dpram.vhd
 set_global_assignment -name VHDL_FILE rtl/ps2_keyboard.vhdl
 set_global_assignment -name VHDL_FILE rtl/ps2_to_pokey.vhdl
 set_global_assignment -name VERILOG_FILE rtl/souper.v
-set_global_assignment -name SYSTEMVERILOG_FILE rtl/tia.sv
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/TIA.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/cart.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/cart2600.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/banks2600.sv


### PR DESCRIPTION
There is a file rtl/TIA.sv that is referenced by the string 'rtl/tia.sv'.
This works on Windows, because its file system is case insensitive.
But fails on Linux.

This PR fixes that.