### PR TITLE
Some enhancements

### DIFF
--- a/Atari7800.sv
+++ b/Atari7800.sv
@@ -693,22 +693,7 @@ sdram sdram
 	.ch0_din    (cart_download ? ioctl_dout : cart_din),
 	.ch0_rd     (cart_read & ~cart_download & ~reset),
 	.ch0_dout   (cart_data_sd),
-	.ch0_busy   (cart_busy),
-
-	.ch1_addr   (/*cartram_addr*/),
-	.ch1_wr     (/*cartram_wr*/),
-	.ch1_din    (/*cartram_wrdata*/),
-	.ch1_rd     (/*cartram_rd*/),
-	.ch1_dout   (/*cartram_data*/),
-	.ch1_busy   (/*cartram_busy*/),
-
-	// reserved for backup ram save/load
-	.ch2_addr   (  ),
-	.ch2_wr     (  ),
-	.ch2_din    (  ),
-	.ch2_rd     (  ),
-	.ch2_dout   (  ),
-	.ch2_busy   (  )
+	.ch0_busy   (cart_busy)
 );
 
 //////////////////////////////  IO  /////////////////////////////////////

--- a/rtl/cart.sv
+++ b/rtl/cart.sv
@@ -78,8 +78,8 @@ logic pokey_irq_n, ym_irq_n;
 logic [31:0] cart_size_bs;
 
 wire XCTRL1_cs = (cart_xm[0] && address_in[15:4] == 8'h47) && cart_cs;
+assign cart_read = rw && cart_cs && ~cartram_cs;
 always @(posedge clk_sys) begin
-	cart_read <= rw && cart_cs;
 	if (reset) begin
 		XCTRL1 <= 0;
 	end else if (pclk0) begin
@@ -308,8 +308,9 @@ end
 
 wire [14:0] bankset_ram_addr = {bankset_banks | (~rw & &address_in[15:14]), address_in[13:0]};
 assign cartram_addr = is_bankset_mem ? bankset_ram_addr : (souper_en ? souper_addr[17:0] : ({ram_bank, address_in[13:0]} & ram_mask));
-assign cartram_wr = ((ram_cs || (~souper_ram_cs && souper_en)) && ~rw && pclk0);
-assign cartram_rd = ~cartram_wr;
+wire   cartram_cs = (ram_cs || (~souper_ram_cs && souper_en));
+assign cartram_wr = cartram_cs && ~rw;
+assign cartram_rd = cartram_cs &&  rw;
 assign cartram_wrdata = din;
 assign ram_dout = cartram_data;
 

--- a/rtl/cart2600.sv
+++ b/rtl/cart2600.sv
@@ -146,8 +146,8 @@ module cart2600
 	assign rom_addr[BANKDPCP]     = '0;
 
 	assign cartram_addr = sel_ram_a;
-	assign cartram_wr = ~sel_ram_rw && sel_ram_sel && ~address_change;
-	assign cartram_rd = sel_ram_sel && ~cartram_wr;
+	assign cartram_wr = sel_ram_sel && ~sel_ram_rw && ~phi1 && ~address_change;
+	assign cartram_rd = sel_ram_sel &&  sel_ram_rw && ~phi1 && ~address_change;
 	assign cartram_wrdata = d_in;
 	assign cr_do = cartram_data;
 

--- a/rtl/sdram.sv
+++ b/rtl/sdram.sv
@@ -44,28 +44,14 @@ module sdram
 	input             ch0_wr,
 	input       [7:0] ch0_din,
 	output reg  [7:0] ch0_dout,
-	output reg        ch0_busy,
-
-	input      [24:0] ch1_addr,
-	input             ch1_rd,
-	input             ch1_wr,
-	input       [7:0] ch1_din,
-	output reg  [7:0] ch1_dout,
-	output reg        ch1_busy,
-
-	input      [24:0] ch2_addr,
-	input             ch2_rd,
-	input             ch2_wr,
-	input       [7:0] ch2_din,
-	output reg  [7:0] ch2_dout,
-	output reg        ch2_busy
+	output reg        ch0_busy
 );
 
 assign SDRAM_nCS = 0;
 assign SDRAM_CKE = 1;
 assign {SDRAM_DQMH,SDRAM_DQML} = SDRAM_A[12:11];
 
-localparam RASCAS_DELAY   = 3'd1; // tRCD=20ns -> 2 cycles@85MHz
+localparam RASCAS_DELAY   = 3'd2; // tRCD=20ns -> 2 cycles@85MHz
 localparam BURST_LENGTH   = 3'd0; // 0=1, 1=2, 2=4, 3=8, 7=full page
 localparam ACCESS_TYPE    = 1'd0; // 0=sequential, 1=interleaved
 localparam CAS_LATENCY    = 3'd2; // 2/3 allowed
@@ -78,7 +64,7 @@ localparam STATE_IDLE  = 3'd0;             // state to check the requests
 localparam STATE_START = STATE_IDLE+1'd1;  // state in which a new command is started
 localparam STATE_NEXT  = STATE_START+1'd1; // state in which a new command is started
 localparam STATE_CONT  = STATE_START+RASCAS_DELAY;
-localparam STATE_READY = STATE_CONT+CAS_LATENCY+2'd2;
+localparam STATE_READY = STATE_CONT+CAS_LATENCY+2'd1;
 localparam STATE_LAST  = STATE_READY;      // last state in cycle
 
 reg  [2:0] state;
@@ -88,16 +74,16 @@ reg [15:0] data;
 reg        we;
 reg        ram_req=0;
 
-wire [2:0] rd,wr;
+wire       rd,wr;
 
-assign rd = {ch2_rd, ch1_rd, ch0_rd};
-assign wr = {ch2_wr, ch1_wr, ch0_wr};
+assign rd = ch0_rd;
+assign wr = ch0_wr;
 
 // access manager
 always @(posedge clk) begin
 	reg old_ref;
-	reg  [2:0] old_rd,old_wr;//,rd,wr;
-	reg [24:1] last_a[3] = '{'1,'1,'1};
+	reg old_rd,old_wr;//,rd,wr;
+	reg [24:1] last_a = '1;
 
 	old_rd <= old_rd & rd;
 	old_wr <= old_wr & wr;
@@ -106,47 +92,21 @@ always @(posedge clk) begin
 		ram_req <= 0;
 		we <= 0;
 		ch0_busy <= 0;
-		ch1_busy <= 0;
-		ch2_busy <= 0;
-		if((~old_rd[0] & rd[0]) | (~old_wr[0] & wr[0])) begin
-			old_rd[0] <= rd[0];
-			old_wr[0] <= wr[0];
-			we <= wr[0];
+		if((~old_rd & rd) | (~old_wr & wr)) begin
+			old_rd <= rd;
+			old_wr <= wr;
+			we <= wr;
 			{bank,a} <= ch0_addr;
 			data <= {ch0_din,ch0_din};
-			ram_req <= wr[0] || (last_a[0] != ch0_addr[24:1]);
-			last_a[0] <= wr[0] ? '1 : ch0_addr[24:1];
+			ram_req <= wr || (last_a != ch0_addr[24:1]);
+			last_a <= wr ? '1 : ch0_addr[24:1];
 			ch0_busy <= 1;
-			state <= STATE_START;
-		end
-		else if((~old_rd[1] & rd[1]) | (~old_wr[1] & wr[1])) begin
-			old_rd[1] <= rd[1];
-			old_wr[1] <= wr[1];
-			we <= wr[1];
-			{bank,a} <= ch1_addr;
-			data <= {ch1_din,ch1_din};
-			ram_req <= wr[1] || (last_a[1] != ch1_addr[24:1]);
-			last_a[1] <= wr[1] ? '1 : ch1_addr[24:1];
-			ch1_busy <= 1;
-			state <= STATE_START;
-		end
-		else if((~old_rd[2] & rd[2]) | (~old_wr[2] & wr[2])) begin
-			old_rd[2] <= rd[2];
-			old_wr[2] <= wr[2];
-			we <= wr[2];
-			{bank,a} <= ch2_addr;
-			data <= {ch2_din,ch2_din};
-			ram_req <= wr[2] || (last_a[2] != ch2_addr[24:1]);
-			last_a[2] <= wr[2] ? '1 : ch2_addr[24:1];
-			ch2_busy <= 1;
 			state <= STATE_START;
 		end
 	end
 
 	if (state == STATE_READY) begin
 		ch0_busy <= 0;
-		ch1_busy <= 0;
-		ch2_busy <= 0;
 	end
 
 	if(mode != MODE_NORMAL || state != STATE_IDLE || reset) begin
@@ -189,11 +149,10 @@ localparam CMD_AUTO_REFRESH    = 3'b001;
 localparam CMD_LOAD_MODE       = 3'b000;
 
 wire [1:0] dqm = {we & ~a[0], we & a[0]};
+reg [15:0] last_data;
 
 // SDRAM state machines
 always @(posedge clk) begin
-	reg [15:0] last_data[3];
-	reg [15:0] data_reg;
 
 	if(state == STATE_START) SDRAM_BA <= (mode == MODE_NORMAL) ? bank : 2'b00;
 
@@ -222,42 +181,16 @@ always @(posedge clk) begin
 		                          default: SDRAM_A <= 13'b0000000000000;
 	endcase
 
-	data_reg <= SDRAM_DQ;
-
 	if(state == STATE_READY) begin
 		if(ch0_busy) begin
 			if(ram_req) begin
-				if(we) ch0_dout <= data[7:0];
-				else begin
-					ch0_dout <= a[0] ? data_reg[15:8] : data_reg[7:0];
-					last_data[0] <= data_reg;
-				end
+				if(!we) last_data <= SDRAM_DQ;
 			end
-			else ch0_dout <= a[0] ? last_data[0][15:8] : last_data[0][7:0];
-		end
-		if(ch1_busy) begin
-			if(ram_req) begin
-				if(we) ch1_dout <= data[7:0];
-				else begin
-					ch1_dout <= a[0] ? data_reg[15:8] : data_reg[7:0];
-					last_data[1] <= data_reg;
-				end
-			end
-			else ch1_dout <= a[0] ? last_data[1][15:8] : last_data[1][7:0];
-		end
-		if(ch2_busy) begin
-			if(ram_req) begin
-				if(we) ch2_dout <= data[7:0];
-				else begin
-					ch2_dout <= a[0] ? data_reg[15:8] : data_reg[7:0];
-					last_data[2] <= data_reg;
-				end
-			end
-			else ch2_dout <= a[0] ? last_data[2][15:8] : last_data[2][7:0];
 		end
 	end
 end
 
+assign ch0_dout = we ? data[7:0] : a[0] ? last_data[15:8] : last_data[7:0];
 
 altddio_out
 #(

--- a/rtl/top.sv
+++ b/rtl/top.sv
@@ -419,8 +419,8 @@ module Atari7800(
 		.tia_mode     (tia_mode)
 	);
 
-	assign cartram_wr = tia_en ? cartram_wr26 : cartram_wr78;
-	assign cartram_rd = tia_en ? cartram_rd26 : cartram_rd78;
+	assign cartram_wr = tia_en ? cartram_wr26 : (cartram_wr78 & mclk1);
+	assign cartram_rd = tia_en ? cartram_rd26 : (cartram_rd78 & mclk1);
 	assign cartram_addr = tia_en ? cartram_addr26 : cartram_addr78;
 	assign cartram_wrdata = tia_en ? cartram_wrdata26 : cartram_wrdata78;
 
@@ -431,6 +431,7 @@ module Atari7800(
 		reset_addr <= (reset && ~old_reset) ? 16'd0 : reset_addr + 1'd1;
 	end
 
+`ifndef EXTERNAL_CARTRAM
 	spram #(.addr_width(17), .mem_name("CART")) cart_ram
 	(
 		.clock   (clk_sys),
@@ -440,6 +441,9 @@ module Atari7800(
 		.q       (cartram_data_bram),
 		.cs      (~pause)
 	);
+`else
+	assign cartram_data_bram = cartram_data;
+`endif
 
 	cart cart
 	(


### PR DESCRIPTION
- save 64K BRAM in video_muxer
- possibility to use the SDRAM for cartram, too - the full 18 bit address space is usable (not added to the toplevel, as I cannot test it without a de10-nano)
- use tRCD=2 cycles, but don't register the SDRAM output twice - same data delay, but obey the datasheet

I only compile-tested these with the MiSTer target, but they're working well on MiST.
The cartram move to SDRAM needs a simple address multiplexer in the toplevel, like this:
https://github.com/gyurco/Atari7800_FPGA/blob/4e0a8cd9a3cdc37945e89921d5166fd91a6ca098/mist/Atari7800_MiST.sv#L658
