### PR TITLE
Recalc checksums.  Add option to Atari2600 menu. Always enable Atari2…

### DIFF
--- a/Atari7800.qsf
+++ b/Atari7800.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Lite Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files

--- a/Atari7800.sv
+++ b/Atari7800.sv
@@ -225,7 +225,7 @@ reg old_cart_download;
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXX   XXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXX  XXXXXXXXX
 
 `include "build_id.v"
 parameter CONF_STR = {
@@ -268,14 +268,15 @@ parameter CONF_STR = {
 	"P2o01,Gun Control,Joy1,Joy2,Mouse;",
 	"P2o2,Gun Fire,Joy,Mouse;",
 	"P2o45,Cross,Small,Medium,Big,None;",
-	"D2P4,Atari2600;",
+	"P4,Atari2600;",
 	"D2P4oT,Flickerblend,Off,On;",
 	"D2P4oV,Stabilize Video,On,Off;",
 	"D2P4oF,De-comb,Off,On;",
 	"D2P4oU,Black & White,Off,On;",
 	"D2P4oOS,Bankswitching,Auto,F8,F6,FE,E0,3F,F4,P2,FA,CV,2K,UA,E7,F0,32,AR,3E,SB,WD,EF;",
+	"P4oN,Fix SC File Checksums,Off,On;",
 	"D2P4-;",
-	"D2P4rG,Load Tape From ADC;",
+	"P4rG,Load Tape From ADC;",
 	"P3,Advanced;",
 	"P3OH,Bypass Bios,Yes,No;",
 	"P3O1,Clear Memory,Zero,Random;",
@@ -570,6 +571,7 @@ Atari7800 main
 	.decomb       (status[47]),
 	.mapper       (status[60:56]),
 	.tape_in      ({use_tape, tape_adc}),
+	.fix_sc_cs    (status[55]),
 
 	// Palette loading
 	.pal_load     (pal_download),

--- a/rtl/cart2600.sv
+++ b/rtl/cart2600.sv
@@ -39,7 +39,8 @@ module cart2600
 
 	// Tape Signals
 	output          tape_audio, // Tape audio output
-	input    [1:0]  tape_in     // ADC tape input
+	input    [1:0]  tape_in,    // ADC tape input
+	input           fix_sc_cs   // Fix Supercharger Checksums menu option
 );
 	`define NUM_MAPPERS BANKEND
 
@@ -437,7 +438,8 @@ module cart2600
 		.rom_do     (rom_do),
 		.rom_size   (rom_size),
 		.audio_data (tape_audio),
-		.tape_in    (tape_in)
+		.tape_in    (tape_in),
+		.fix_sc_cs  (fix_sc_cs)
 	);
 
 	mapper_WD mapper_WD

--- a/rtl/top.sv
+++ b/rtl/top.sv
@@ -75,6 +75,7 @@ module Atari7800(
 	input logic [7:0]  clearval,
 	input logic [7:0]  random,
 	input logic [1:0]  tape_in,
+	input logic        fix_sc_cs,
 	output logic       tia_hsync,
 	input  logic       use_stereo,
 	input [10:0]       ps2_key,
@@ -511,7 +512,8 @@ module Atari7800(
 		.oe             (),
 		.open_bus       (open_bus),
 		.tape_in        (tape_in),
-		.tape_audio     (tape_audio)
+		.tape_audio     (tape_audio),
+		.fix_sc_cs      (fix_sc_cs)
 	);
 
 endmodule


### PR DESCRIPTION
Some Supercharger files do not have the correct checksums in them, particularly homebrew games.  This change adds a menu item to the Atari2600 submenu which will force the header and bank checksums to be recalculated, allowing for a successful load.  This change also always enables the Atari2600 menu item and the following two items under that submenu: "Fix SC File Checksums" and "Load Tape From ADC".  This removes the need to first load an Atari 2600 file before accessing these two items.