### PR TITLE
Disable Load ADC menu item unless already in Atari2600 mode

### DIFF
--- a/Atari7800.sv
+++ b/Atari7800.sv
@@ -276,7 +276,7 @@ parameter CONF_STR = {
 	"D2P4oOS,Bankswitching,Auto,F8,F6,FE,E0,3F,F4,P2,FA,CV,2K,UA,E7,F0,32,AR,3E,SB,WD,EF;",
 	"P4oN,Fix SC File Checksums,Off,On;",
 	"D2P4-;",
-	"P4rG,Load Tape From ADC;",
+	"D2P4rG,Load Tape From ADC;",
 	"P3,Advanced;",
 	"P3OH,Bypass Bios,Yes,No;",
 	"P3O1,Clear Memory,Zero,Random;",


### PR DESCRIPTION
Disable "Load Tape from ADC" item under Atari2600 menu again.  It will not go to the Supercharger load screen if the system is not already in Atari 2600 mode.  Leaving it enabled will confuse people into thinking it's broken if they try to select it without first loading an Atari 2600 file.  I don't have the ability to test loading from ADC, so I'll leave this up to someone smarter to figure out.  Sorry for the bother.  My original change to recalculate Supercharger file checksums remains and has been tested with single and multi-load files.
